### PR TITLE
specify REST API version `2022-11-28`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,13 @@
 # Yet Another Create Release Action
 
 This GitHub Action creates a release.
+[actions/create-release] is a great action, but it is currently unmaintained.
+So I created another one.
 
 ## SYNOPSIS
+
+The action is compatible with [actions/create-release].
+It will work just by replacing the workflow's `actions/create-release` with `shogo82148/actions-create-release`.
 
 ```yaml
 on:
@@ -43,11 +48,11 @@ A file with contents describing the release. Optional, and not needed if using b
 
 ### draft
 
-true to create a draft (unpublished) release, false to create a published one. Default: false
+`true` to create a draft (unpublished) release, `false` to create a published one. Default: `false`.
 
 ### prerelease
 
-true to identify the release as a prerelease. false to identify the release as a full release. Default: false
+`true` to identify the release as a prerelease. `false` to identify the release as a full release. Default: `false`.
 
 ### make_latest
 
@@ -59,11 +64,11 @@ based on the release creation date and higher semantic version.
 
 ### commitish
 
-Any branch or commit SHA the Git tag is created from, unused if the Git tag already exists. Default: SHA of current commit
+Any branch or commit SHA the Git tag is created from, unused if the Git tag already exists. Default: SHA of current commit.
 
 ### owner
 
-The name of the owner of the repo. Used to identify the owner of the repository. Used when cutting releases for external repositories. Default: Current owner
+The name of the owner of the repo. Used to identify the owner of the repository. Used when cutting releases for external repositories. Default: Current owner.
 
 ### repo
 
@@ -99,8 +104,14 @@ The URL for uploading assets to the release, which could be used by GitHub Actio
 
 ## Related works
 
-- [actions/create-release](https://github.com/actions/create-release)
-- [elgohr/Github-Release-Action](https://github.com/elgohr/Github-Release-Action)
-- [marvinpinto/action-automatic-releases](https://github.com/marvinpinto/action-automatic-releases)
-- [softprops/action-gh-release](https://github.com/softprops/action-gh-release)
-- [ncipollo/release-action](https://github.com/ncipollo/release-action)
+- [actions/create-release]
+- [elgohr/Github-Release-Action]
+- [marvinpinto/action-automatic-releases]
+- [softprops/action-gh-release]
+- [ncipollo/release-action]
+
+[actions/create-release]: https://github.com/actions/create-release
+[elgohr/github-release-action]: https://github.com/elgohr/Github-Release-Action
+[marvinpinto/action-automatic-releases]: https://github.com/marvinpinto/action-automatic-releases
+[softprops/action-gh-release]: https://github.com/marvinpinto/action-automatic-releases
+[ncipollo/release-action]: https://github.com/ncipollo/release-action

--- a/src/create-release.ts
+++ b/src/create-release.ts
@@ -89,8 +89,9 @@ async function readFile(path: string): Promise<string> {
 const newGitHubClient = (token: string): http.HttpClient => {
   return new http.HttpClient("shogo82148-actions-create-release/v1", [], {
     headers: {
-      Authorization: `token ${token}`,
-      Accept: "application/vnd.github.v3+json",
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
     },
   });
 };

--- a/src/create-release.ts
+++ b/src/create-release.ts
@@ -117,7 +117,7 @@ interface ReposCreateReleaseResponse {
 }
 
 // minium implementation of create a release API
-// https://docs.github.com/en/rest/reference/repos#create-a-release
+// https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release
 const createRelease = async (
   params: ReposCreateReleaseParams
 ): Promise<ReposCreateReleaseResponse> => {

--- a/src/publish-release.ts
+++ b/src/publish-release.ts
@@ -37,8 +37,9 @@ export async function publish(opt: Options): Promise<void> {
 const newGitHubClient = (token: string): http.HttpClient => {
   return new http.HttpClient("shogo82148-actions-create-release/v1", [], {
     headers: {
-      Authorization: `token ${token}`,
-      Accept: "application/vnd.github.v3+json",
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
     },
   });
 };
@@ -53,8 +54,8 @@ interface ReposUpdateReleaseParams {
   make_latest?: MakeLatest | undefined;
 }
 
-// minium implementation of create a release API
-// https://docs.github.com/en/rest/reference/repos#create-a-release
+// minium implementation of update a release API
+// https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#update-a-release
 const updateRelease = async (params: ReposUpdateReleaseParams): Promise<void> => {
   const client = newGitHubClient(params.github_token);
   const raw: { [key: string]: string | boolean } = {


### PR DESCRIPTION
> You must specify which REST API version to use whenever you make a request to the REST API.

https://docs.github.com/en/rest/overview/api-versions?apiVersion=2022-11-28